### PR TITLE
Use shared workspace dependencies more

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,21 @@
 members = ["libseed", "seedctl", "web"]
 resolver = "2"
 
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+
 [workspace.dependencies]
+anyhow = "1.0.75"
+clap = { version = "4.4.11", features = ["derive"] }
 libseed = { path = "./libseed", version = "0.1.0" }
+serde = { version = "1.0.203", features = ["serde_derive"] }
+sqlx = { version = "0.8.2", features = [ "sqlite", "runtime-tokio" ] }
+strum = "0.26.0"
+strum_macros = "0.26.0"
+thiserror = "1.0.63"
+time = { version = "0.3.31", features = ["formatting", "serde"] }
+tokio = { version = "1.34.0", features = [ "full" ] }
+tracing = "0.1.40"
+tracing-subscriber = "0.3.18"
+xdg = "2.5.2"

--- a/libseed/Cargo.toml
+++ b/libseed/Cargo.toml
@@ -1,24 +1,27 @@
 [package]
 name = "libseed"
-version = "0.1.0"
-edition = "2021"
+version = { workspace = true }
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-strum = "0.26.0"
-strum_macros = "0.26.0"
-sqlx = { version = "0.8.2", features = [ "sqlite", "runtime-tokio", "time" ] }
-tokio = { version = "1.34.0", features = [ "full" ] }
-serde = { version = "1.0.193", features = ["serde_derive"] }
-anyhow = "1.0.75"
-tracing = "0.1.40"
-time = { version = "0.3.31", features = ["formatting", "local-offset", "serde", "parsing"] }
-password-hash = { version = "0.5.0", features = ["std", "getrandom"] }
+# shared workspace dependencies
+anyhow = { workspace = true }
+serde = { workspace = true }
+sqlx = { workspace = true, features = [ "sqlite", "runtime-tokio", "time" ] }
+strum_macros = { workspace = true }
+strum = { workspace = true }
+thiserror = { workspace = true }
+time = { workspace = true, features = ["local-offset", "parsing"] }
+tokio = { workspace = true }
+tracing = { workspace = true }
+
+# local dependencies
 argon2 = "0.5.2"
 async-trait = "0.1.77"
-thiserror = "1.0.56"
+password-hash = { version = "0.5.0", features = ["std", "getrandom"] }
 
 [dev-dependencies]
-tracing-subscriber = "0.3.18"
 test-log = "0.2.14"
+tracing-subscriber = { workspace = true }

--- a/seedctl/Cargo.toml
+++ b/seedctl/Cargo.toml
@@ -1,27 +1,28 @@
 [package]
 name = "seedctl"
-version = "0.1.0"
-edition = "2021"
+version = { workspace = true }
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.75"
-clap = { version = "4.4.11", features = ["derive"] }
-sqlx = { version = "0.8.2", features = [ "sqlite", "runtime-tokio" ] }
-tabled = "0.16.0"
-tokio = { version = "1.34.0", features = [ "full" ] }
+# shared workspace dependencies
+anyhow = { workspace = true }
+clap = { workspace = true }
+libseed = { workspace = true }
+serde = { workspace = true }
+sqlx = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing-subscriber = { workspace = true }
+tracing = { workspace = true }
+xdg = { workspace = true }
 
-# local deps
-libseed.workspace = true
-tracing = "0.1.40"
-tracing-subscriber = "0.3.18"
-serde = { version = "1.0.203", features = ["serde_derive"] }
-serde_json = "1.0.118"
-xdg = "2.5.2"
+# local dependencies
+csv = "1.3.0"
+futures = "0.3.30"
 inquire = { version = "0.7.5", features = ["editor"] }
 password-hash = "0.5.0"
-futures = "0.3.30"
-thiserror = "1.0.63"
-csv = "1.3.0"
+serde_json = "1.0.118"
 serde_yaml = "0.9.34"
+tabled = "0.16.0"

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -1,41 +1,42 @@
 [package]
 name = "seedweb"
-version = "0.1.0"
-edition = "2021"
+version = { workspace = true }
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# local deps
-libseed.workspace = true
+# shared workspace deps
+anyhow = { workspace = true }
+clap = { workspace = true }
+libseed = { workspace = true }
+serde = { workspace = true }
+sqlx = { workspace = true }
+strum = { workspace = true }
+thiserror = { workspace = true }
+time = { workspace = true }
+tokio = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tracing = { workspace = true }
+xdg = { workspace = true }
 
-anyhow = "1.0.75"
-axum = { version = "0.7.2", features = ["macros"] }
+# local dependencies
 axum-login = "0.16.0"
+axum-server = { version = "0.7.0", features = ["tls-rustls"] }
 axum-template = { version = "2.3.0", features = ["minijinja"] }
-clap = { version = "4.4.11", features = ["derive"] }
+axum = { version = "0.7.2", features = ["macros"] }
+lettre = { version = "0.11.3", features = ["serde", "tracing", "sendmail-transport", "file-transport", "tokio1", "tokio1-native-tls"] }
+minijinja-contrib = { version = "2.0.3", features = ["datetime"] }
 minijinja = { version = "2.0.3", features = ["loader"] }
-serde = { version = "1.0.193", features = ["serde_derive"] }
-sqlx = { version = "0.8.2", features = [ "sqlite", "runtime-tokio" ] }
-strum = "0.26.0"
-thiserror = "1.0.52"
-time = { version = "0.3.31", features = ["formatting", "serde"] }
-tokio = { version = "1.34.0", features = [ "full" ] }
+pulldown-cmark = "0.12.0"
+rand = "0.8.5"
+serde_urlencoded = "0.7.1"
+serde_yaml = "0.9.30"
 tower = "0.4.13"
 tower-http = { version = "0.5.2", features = ["fs", "trace", "request-id", "util"] }
 tower-sessions = "0.13.0"
 tower-sessions-sqlx-store = { version = "0.14.0", features = ["sqlite"]}
-tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-axum-server = { version = "0.7.0", features = ["tls-rustls"] }
-serde_urlencoded = "0.7.1"
-serde_yaml = "0.9.30"
-minijinja-contrib = { version = "2.0.3", features = ["datetime"] }
-pulldown-cmark = "0.12.0"
-rand = "0.8.5"
-lettre = { version = "0.11.3", features = ["serde", "tracing", "sendmail-transport", "file-transport", "tokio1", "tokio1-native-tls"] }
 uuid = { version = "1.7.0", features = ["v4"] }
-xdg = "2.5.2"
 
 [dev-dependencies]
 http-body-util = "0.1.0"


### PR DESCRIPTION
For dependencies that are present in more than one workspace, add them
to the workspace dependencies in /Cargo.toml and inherit them from the
other packages.
