### PR TITLE
Don't trigger github workflows twice when opening a PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,10 @@
-
-on: [push, pull_request, workflow_dispatch]
-
 name: Continuous integration
-
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 jobs:
   check:
     name: Check
@@ -13,7 +15,6 @@ jobs:
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - run: cargo check
-
   test:
     name: Test Suite
     runs-on: ubuntu-latest
@@ -26,7 +27,6 @@ jobs:
         env:
           MDEVCTL_LOG: debug
           RUST_BACKTRACE: full
-
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
@@ -37,7 +37,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - run: rustup component add rustfmt
       - run: cargo fmt --all -- --check
-
   clippy:
     name: Clippy
     runs-on: ubuntu-latest


### PR DESCRIPTION
Opening a pull request with `gh pr create` will push the branch to the
repository and open a pull request. Both of these events will trigger a
github workflow. In order to avoid duplication, only trigger workflows
when pushing to `main` and opening pull requests.

Signed-off-by: Jonathon Jongsma <jonathon@quotidian.org>
