### PR TITLE
web: change the markdown auto-link implementation

### DIFF
--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -37,7 +37,6 @@ tower-sessions = "0.13.0"
 tower-sessions-sqlx-store = { version = "0.14.0", features = ["sqlite"]}
 uuid = { version = "1.7.0", features = ["v4"] }
 signal-hook = "0.3.17"
-regex = "1.11.0"
 
 [dev-dependencies]
 http-body-util = "0.1.0"

--- a/web/src/util.rs
+++ b/web/src/util.rs
@@ -2,8 +2,7 @@ use std::collections::HashMap;
 
 use axum::http::Uri;
 use minijinja::ErrorKind;
-use pulldown_cmark::Event;
-use regex::Regex;
+use pulldown_cmark::{BrokenLink, BrokenLinkCallback};
 
 use crate::APP_PREFIX;
 
@@ -74,68 +73,46 @@ pub fn format_quantity(qty: f64) -> String {
     format!("{metric} ({imperial})")
 }
 
+struct ObjectLinkResolver;
+
+impl<'input> BrokenLinkCallback<'input> for ObjectLinkResolver {
+    fn handle_broken_link(
+        &mut self,
+        link: BrokenLink<'input>,
+    ) -> Option<(
+        pulldown_cmark::CowStr<'input>,
+        pulldown_cmark::CowStr<'input>,
+    )> {
+        link.reference
+            .chars()
+            .nth(0)
+            .and_then(|ch| match ch {
+                'S' => Some("sample"),
+                'L' => Some("source"),
+                'P' => Some("project"),
+                _ => None,
+            })
+            .and_then(|slug| {
+                link.reference
+                    .get(1..)
+                    .and_then(|s| s.parse::<i64>().ok())
+                    .map(|id| {
+                        (
+                            app_url(&format!("/{slug}/{id}")).into(),
+                            format!("{slug} #{id}").into(),
+                        )
+                    })
+            })
+    }
+}
+
 pub fn markdown(value: Option<&str>) -> minijinja::Value {
     let value = value.unwrap_or("");
-    let re = Regex::new(r"(?<tag>[SLP])(?<id>[0-9]{4,})").expect("Unable to create regex");
-    let parser = pulldown_cmark::Parser::new(value).flat_map(|event| {
-        match event {
-            Event::Text(ref txt) => (|| {
-                let mut events: Vec<Event> = Vec::new();
-                let captures = re.captures_iter(txt);
-                let mut prev: Option<regex::Captures> = None;
-                for capture in captures {
-                    let start = match prev {
-                        None => 0,
-                        Some(prevcapture) => prevcapture.get(0)?.end(),
-                    };
-                    // if there was a plain-text segment between the end
-                    // of the last match and the start of this match, emit that first
-                    let overall = capture.get(0)?;
-                    if start < overall.start() {
-                        let substr = &txt[start..overall.start()];
-                        events.push(Event::Text(substr.to_string().into()));
-                    }
-
-                    // now output a link to the object
-                    let url = (|| {
-                        let tag = capture.name("tag")?.as_str();
-                        let slug = match tag {
-                            "S" => Some("sample"),
-                            "L" => Some("source"),
-                            "P" => Some("project"),
-                            _ => None,
-                        }?;
-                        let id: i64 = capture.name("id")?.as_str().parse().ok()?;
-                        Some(app_url(&format!("/{slug}/{id}")))
-                    })()?;
-
-                    events.push(Event::Start(pulldown_cmark::Tag::Link {
-                        link_type: pulldown_cmark::LinkType::Inline,
-                        dest_url: url.into(),
-                        id: "".into(),
-                        title: "".into(),
-                    }));
-                    events.push(Event::Text(overall.as_str().to_string().into()));
-                    events.push(Event::End(pulldown_cmark::TagEnd::Link));
-                    prev = Some(capture);
-                }
-                let end = match prev {
-                    Some(capture) => capture.get(0)?.end(),
-                    // we never captured anything, so the whole string is just text
-                    None => 0,
-                };
-                if end < txt.len() {
-                    // one last text event
-                    let substr = &txt[end..];
-                    events.push(Event::Text(substr.to_string().into()))
-                }
-                Some(events)
-            })(),
-            _ => None,
-        }
-        .unwrap_or(vec![event])
-        .into_iter()
-    });
+    let parser = pulldown_cmark::Parser::new_with_broken_link_callback(
+        value,
+        pulldown_cmark::Options::empty(),
+        Some(ObjectLinkResolver),
+    );
     let mut output = String::new();
     pulldown_cmark::html::push_html(&mut output, parser);
     minijinja::Value::from_safe_string(output)
@@ -144,14 +121,21 @@ pub fn markdown(value: Option<&str>) -> minijinja::Value {
 #[test]
 fn test_markdown_ids() {
     assert_eq!(
-        markdown(Some("S0006")).as_str(),
-        Some(format!("<p><a href=\"{}\">S0006</a></p>\n", app_url("/sample/6")).as_str())
-    );
-    assert_eq!(
-        markdown(Some("L0006 and S0123 and P9999")).as_str(),
+        markdown(Some("[S0006]")).as_str(),
         Some(
             format!(
-                "<p><a href=\"{}\">L0006</a> and <a href=\"{}\">S0123</a> and <a href=\"{}\">P9999</a></p>\n",
+                "<p><a href=\"{}\" title=\"sample #6\">S0006</a></p>\n",
+                app_url("/sample/6")
+            )
+            .as_str()
+        )
+    );
+    assert_eq!(markdown(Some("S0006")).as_str(), Some("<p>S0006</p>\n"));
+    assert_eq!(
+        markdown(Some("[L0006] and [S0123] and [P9999]")).as_str(),
+        Some(
+            format!(
+                "<p><a href=\"{}\" title=\"source #6\">L0006</a> and <a href=\"{}\" title=\"sample #123\">S0123</a> and <a href=\"{}\" title=\"project #9999\">P9999</a></p>\n",
                 app_url("/source/6"),
                 app_url("/sample/123"),
                 app_url("/project/9999"),
@@ -160,15 +144,46 @@ fn test_markdown_ids() {
         )
     );
     assert_eq!(
-        markdown(Some("L0006")).as_str(),
-        Some(format!("<p><a href=\"{}\">L0006</a></p>\n", app_url("/source/6")).as_str())
+        markdown(Some("L0006 and [S0123] and [B9999]")).as_str(),
+        Some(
+            format!(
+                "<p>L0006 and <a href=\"{}\" title=\"sample #123\">S0123</a> and [B9999]</p>\n",
+                app_url("/sample/123"),
+            )
+            .as_str()
+        )
     );
     assert_eq!(
-        markdown(Some("P0006")).as_str(),
-        Some(format!("<p><a href=\"{}\">P0006</a></p>\n", app_url("/project/6")).as_str())
+        markdown(Some("[L0006]")).as_str(),
+        Some(
+            format!(
+                "<p><a href=\"{}\" title=\"source #6\">L0006</a></p>\n",
+                app_url("/source/6")
+            )
+            .as_str()
+        )
     );
-    assert_eq!(markdown(Some("X0006")).as_str(), Some("<p>X0006</p>\n"));
-    assert_eq!(markdown(Some("S006")).as_str(), Some("<p>S006</p>\n"));
+    assert_eq!(
+        markdown(Some("[P0006]")).as_str(),
+        Some(
+            format!(
+                "<p><a href=\"{}\" title=\"project #6\">P0006</a></p>\n",
+                app_url("/project/6")
+            )
+            .as_str()
+        )
+    );
+    assert_eq!(markdown(Some("[X0006]")).as_str(), Some("<p>[X0006]</p>\n"));
+    assert_eq!(
+        markdown(Some("[S006]")).as_str(),
+        Some(
+            format!(
+                "<p><a href=\"{}\" title=\"sample #6\">S006</a></p>\n",
+                app_url("/sample/6")
+            )
+            .as_str()
+        )
+    );
     assert_eq!(
         markdown(Some("This is just some text")).as_str(),
         Some("<p>This is just some text</p>\n")


### PR DESCRIPTION
Don't attempt auto-link different objects in markdown. Only link things
that are explicitly linked with markdown link format (e.g. [S0038]).
This should be more expected and will also be a bit more performant
since we don't rescan all text nodes with a regex.

Signed-off-by: Jonathon Jongsma <jonathon@quotidian.org>
