### PR TITLE
lib: optimize db on init and upgrade

### DIFF
--- a/libseed/src/taxonomy.rs
+++ b/libseed/src/taxonomy.rs
@@ -16,7 +16,7 @@ use std::{str::FromStr, sync::Arc};
 use strum_macros::{Display, EnumIter, FromRepr};
 use tracing::debug;
 
-const KINGDOM_PLANTAE: i64 = 3;
+pub(crate) const KINGDOM_PLANTAE: i64 = 3;
 
 /// The taxonomic rank of a taxon
 #[derive(Debug, Clone, Display, EnumIter, FromRepr, Deserialize, Serialize, PartialEq)]


### PR DESCRIPTION
The database has a lot of unnecessary data and we should clean this data
after initializing the database and after upgrading to a new database so
that it doesn't use up too much disk space. Also make sure that the
phylo_sort_seq field gets updated on both init and upgrade.

Fixes #67
Fixes #59

Signed-off-by: Jonathon Jongsma <jonathon@quotidian.org>
