### PR TITLE
web: make filter/sort widget more generic

### DIFF
--- a/libseed/src/core/query.rs
+++ b/libseed/src/core/query.rs
@@ -5,6 +5,7 @@ use serde::{
     de::{IntoDeserializer, value},
 };
 use std::{ops::Deref, str::FromStr, sync::Arc};
+use strum_macros::EnumIter;
 
 pub mod filter {
     use super::DynFilterPart;
@@ -177,13 +178,22 @@ impl ToSql for LimitSpec {
 }
 
 /// A type for specifying the sort order of an SQL query
-#[derive(Deserialize, Serialize, Clone, Debug, Default)]
+#[derive(Deserialize, Serialize, Clone, Copy, Debug, Default, EnumIter, PartialEq)]
 pub enum SortOrder {
     #[serde(rename = "asc")]
     #[default]
     Ascending,
     #[serde(rename = "desc")]
     Descending,
+}
+
+impl std::fmt::Display for SortOrder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SortOrder::Ascending => write!(f, "Ascending"),
+            SortOrder::Descending => write!(f, "Descending"),
+        }
+    }
 }
 
 impl FromStr for SortOrder {

--- a/seedctl/src/commands/samples.rs
+++ b/seedctl/src/commands/samples.rs
@@ -74,7 +74,7 @@ pub(crate) async fn handle_command(
                             acc
                         })
                         .iter()
-                        .map(|field| SortSpec::new(field.clone(), order.clone()))
+                        .map(|field| SortSpec::new(field.clone(), order))
                         .collect(),
                 )
             });

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -41,6 +41,7 @@ tower-http = { version = "0.6", features = ["fs", "trace", "request-id", "util"]
 tower-sessions = "0.14.0"
 tower-sessions-sqlx-store = { version = "0.15.0", features = ["sqlite"]}
 uuid = { version = "1.7.0", features = ["v4"] }
+serde_with = "3.12.0"
 
 [dev-dependencies]
 http-body-util = "0.1.0"

--- a/web/src/html/mod.rs
+++ b/web/src/html/mod.rs
@@ -8,6 +8,7 @@ use axum::{
     routing::get,
 };
 use axum_template::RenderHtml;
+use libseed::core::query::SortOrder;
 use minijinja::context;
 use serde::Serialize;
 
@@ -84,10 +85,29 @@ async fn root(
     ))
 }
 
+#[derive(Serialize)]
+pub(crate) struct FilterSortSpec<T: Serialize> {
+    filter: String,
+    sort_fields: Vec<FilterSortOption<T>>,
+    sort_dirs: Vec<FilterSortOption<SortOrder>>,
+    additional_filters: Vec<FilterSortOption<String>>,
+}
+
 /// A utility type for specifying an option for sorting
 #[derive(Serialize)]
-struct SortOption<T: Serialize> {
+pub(crate) struct FilterSortOption<T: Serialize> {
     name: String,
-    code: T,
+    value: T,
     selected: bool,
+}
+
+/// A utility function for creating the sort order options
+pub(crate) fn sort_dirs(selected: SortOrder) -> Vec<FilterSortOption<SortOrder>> {
+    <SortOrder as strum::IntoEnumIterator>::iter()
+        .map(|val| FilterSortOption {
+            name: val.to_string(),
+            value: val,
+            selected: val == selected,
+        })
+        .collect()
 }

--- a/web/templates/_macros.html.j2
+++ b/web/templates/_macros.html.j2
@@ -77,19 +77,19 @@
 {%- endmacro %}
 
 
-{% macro filter_sort_widget(url, target, options, query) -%}
+{% macro filter_sort_widget(url, target, filter_spec) -%}
     <form
          hx-push-url="true"
          hx-boost="true"
          hx-target="{{ target }}"
          hx-get="{{ url }}"
-         hx-trigger="submit, input changed delay:500ms from:input, change changed delay:500ms, change from:#displayallcheck">
+         hx-trigger="submit, input changed delay:500ms from:input, change changed delay:500ms, change from:input[type=checkbox]">
     <div class="input-group mb-3">
             <input type="text"
                    class="form-control"
                    autofocus
                    placeholder="Filter list..."
-                   value="{{ query.filter or "" }}"
+                   value="{{ filter_spec.filter or "" }}"
                    name="filter">
             <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="dropdownMenuButton1" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">Sort/Filter</button>
             <div class="dropdown-menu dropdown-menu-end">
@@ -98,28 +98,33 @@
                     <div class="mb-3">
                         <label for="sortselect" class="dropdown-header">Sort field</label>
                         <select id="sortselect" class="form-select" name="sort">
-                            {% for option in options %}
-                            <option value="{{ option.code }}" {% if query.sort == option.code %}selected{% endif %}>{{ option.name }}</option>
+                            {% for option in filter_spec.sort_fields %}
+                            <option value="{{ option.value }}" {% if option.selected %}selected{% endif %}>{{ option.name }}</option>
                             {% endfor %}
                         </select>
                     </div>
                     <div class="mb-3">
                         <label for="directionselect" class="dropdown-header">Sort direction</label>
                         <select id="directionselect" class="form-select" name="dir">
-                            <option value="asc" {% if query.filter == "asc" %}selected{% endif %}>{{ "Ascending" }}</option>
-                            <option value="desc" {% if query.filter == "desc" %}selected{% endif %}>{{ "Descending" }}</option>
+                            {% for option in filter_spec.sort_dirs %}
+                            <option value="{{ option.value }}" {% if option.selected %}selected{% endif %}>{{ option.name }}</option>
+                            {% endfor %}
                         </select>
                     </div>
                 </div>
+                {% if filter_spec.additional_filters %}
                 <div class="p-3">
                 <h5>Filter</h5>
                     <div class="mb-3">
                         <div clas="form-check">
-                            <input id="displayallcheck" class="form-check-input" type="checkbox" name="all" value="true" {% if query.all %}checked{% endif %}>
-                            <label class="ms-2 form-check-label" for="displayallcheck">Show empty samples</label>
+                            {% for option in filter_spec.additional_filters %}
+                            <input id="checkbox-{{option.value}}" class="form-check-input" type="checkbox" name="{{ option.value }}" value="true" {% if option.selected %}checked{% endif %}>
+                            <label class="ms-2 form-check-label" for="checkbox-{{option.value}}">{{ option.name }}</label>
+                            {% endfor %}
                         </div>
                     </div>
                 </div>
+                {% endif %}
             </div>
         </div>
     </form>

--- a/web/templates/project_{id}.html.j2
+++ b/web/templates/project_{id}.html.j2
@@ -14,7 +14,7 @@
     <h2>{{ self.title() }} <a href="{{ ("/project/" ~ project.id ~ "/edit") | app_url }}">{{ icon("pencil") }}</a></h2>
     {{ project.description | markdown }}
     <h3>Samples in this project <a class="ms-2" href="{{ ("/project/" ~ project.id) | app_url }}/add">{{ icon("plus-square") }}</a></h3>
-    {{ filter_sort_widget(("/project/" ~ project.id) | app_url, "#project-sample-list", options, query) }}
+    {{ filter_sort_widget(("/project/" ~ project.id) | app_url, "#project-sample-list", filter_spec) }}
     <div id="flash-messages"></div>
         {{ project_sample_list("project-sample-list", project, summary, request_uri) }}
 {% endblock %}

--- a/web/templates/project_{id}_add.html.j2
+++ b/web/templates/project_{id}_add.html.j2
@@ -38,7 +38,7 @@
 {"name": "Add Samples", "active": true }]) }}
 <h2>{{ self.title() }}</h2>
 <p>Choose samples to add to the project <i>{{ project.name }}</i></p>
-{{ filter_sort_widget(("/project/" ~ project.id ~ "/add") | app_url, "#sample-list", sort_options, query)}}
+{{ filter_sort_widget(("/project/" ~ project.id ~ "/add") | app_url, "#sample-list", filter_spec)}}
 <div id="flash-messages" class="sticky-top"></div>
 {% if samples %}
 <form id="project-add-form"

--- a/web/templates/sample_list.html.j2
+++ b/web/templates/sample_list.html.j2
@@ -9,7 +9,7 @@
 {%- endmacro %}
 <h2><span class="me-2">{{ icon("box-seam") }}</span>Samples <a class="ms-2" href="{{ "/sample/new" | app_url }}">{{ icon("plus-square") }}</a></h2>
     <div class="mb-3">
-        {{ filter_sort_widget("/sample/list" | app_url, "#sample-plus-pagination", options, query)}}
+        {{ filter_sort_widget("/sample/list" | app_url, "#sample-plus-pagination", filter_spec)}}
     </div>
     <div id="sample-plus-pagination">
     <div class="text-body-tertiary">{{ summary.total_items }} items found </div>


### PR DESCRIPTION
Don't make this widget specific to sorting and filtering samples. Make
it generic enough that it can be used for other objects as well.

https://github.com/jonner/seedcollection/issues/94

Signed-off-by: Jonathon Jongsma <jonathon@quotidian.org>
