### PR TITLE
web: use secrecy crate to avoid exposing secrets

### DIFF
--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -42,6 +42,7 @@ tower-sessions = "0.14.0"
 tower-sessions-sqlx-store = { version = "0.15.0", features = ["sqlite"]}
 uuid = { version = "1.7.0", features = ["v4"] }
 serde_with = "3.12.0"
+secrecy = { version = "0.10.3", features = ["serde"] }
 
 [dev-dependencies]
 http-body-util = "0.1.0"

--- a/web/src/html/tests/mod.rs
+++ b/web/src/html/tests/mod.rs
@@ -1,4 +1,4 @@
-use crate::{Result, auth::Credentials, test_app, util::app_url};
+use crate::{Result, test_app, util::app_url};
 use axum::{
     Router,
     body::{Body, Bytes, HttpBody},
@@ -41,11 +41,11 @@ where
 
 /// logs the user into the app and returns a cookie value that can be used in subsequent requests
 async fn login(app: &mut Router) -> Result<String> {
-    let creds = serde_urlencoded::to_string(Credentials {
-        username: "testuser".to_string(),
-        password: "topsecret123".to_string(),
-        next: Some("url".to_string()),
-    })?;
+    let creds = serde_urlencoded::to_string([
+        ("username", "testuser"),
+        ("password", "topsecret123"),
+        ("next", "url"),
+    ])?;
     let request = Request::builder()
         .uri(app_url("/auth/login"))
         .method("POST")


### PR DESCRIPTION
Use the SecretString type just to avoid ever leaking passwords or other
sensitive data into debug logs, etc.

Signed-off-by: Jonathon Jongsma <jonathon@quotidian.org>
