### PR TITLE
lib: rename some Cmp enum names

### DIFF
--- a/libseed/src/core/query.rs
+++ b/libseed/src/core/query.rs
@@ -125,8 +125,8 @@ pub mod filter {
         Like,
         LessThan,
         GreaterThan,
-        LessThanEqual,
-        GreatherThanEqual,
+        NotGreaterThan,
+        NotLessThan,
         NumericPrefix,
     }
 
@@ -138,8 +138,8 @@ pub mod filter {
                 Cmp::NumericPrefix | Cmp::Like => write!(f, " LIKE "),
                 Cmp::LessThan => write!(f, " < "),
                 Cmp::GreaterThan => write!(f, " != "),
-                Cmp::LessThanEqual => write!(f, " <= "),
-                Cmp::GreatherThanEqual => write!(f, " >= "),
+                Cmp::NotGreaterThan => write!(f, " <= "),
+                Cmp::NotLessThan => write!(f, " >= "),
             }
         }
     }

--- a/seedctl/src/commands/samples.rs
+++ b/seedctl/src/commands/samples.rs
@@ -51,7 +51,7 @@ pub(crate) async fn handle_command(
                 builder = builder.push(sample::Filter::Quantity(Cmp::NotEqual, 0.0))
             }
             if let Some(rank) = rank {
-                builder = builder.push(sample::Filter::TaxonRank(Cmp::GreatherThanEqual, rank))
+                builder = builder.push(sample::Filter::TaxonRank(Cmp::NotLessThan, rank))
             }
             let sort = sort.map(|vec| {
                 let order = match reverse {


### PR DESCRIPTION
Rename GreatherThanEqual (with spelling mistake) to NotLessThan
Rename LessThanEqual to NotGreaterThan

Signed-off-by: Jonathon Jongsma <jonathon@quotidian.org>
