### PR TITLE
web: re-order the main header menu

### DIFF
--- a/web/templates/root.html.j2
+++ b/web/templates/root.html.j2
@@ -36,16 +36,16 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav me-auto">
                     <li class="nav-item">
-                        <a class="nav-link" href="{{app_prefix}}/taxonomy/">Taxonomy</a>
+                        <a class="nav-link" href="{{app_prefix}}/sample/list">Samples</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="{{app_prefix}}/source/list">Sources</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="{{app_prefix}}/sample/list">Samples</a>
+                        <a class="nav-link" href="{{app_prefix}}/project/list">Projects</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="{{app_prefix}}/project/list">Projects</a>
+                        <a class="nav-link" href="{{app_prefix}}/taxonomy/">Taxonomy</a>
                     </li>
                 </ul>
                 {% if user %}


### PR DESCRIPTION
Make 'samples' first, since it's the most important item. Taxonomy last.

Signed-off-by: Jonathon Jongsma <jonathon@quotidian.org>
