### PR TITLE
web: Fix taxon autocomplete

### DIFF
--- a/web/templates/_sample_macros.html.j2
+++ b/web/templates/_sample_macros.html.j2
@@ -41,7 +41,8 @@ hx-swap="none"
                        autofocus
                        hx-get="{{app_prefix}}/taxonomy/datalist"
                        hx-trigger="input changed delay:500ms"
-                       hx-target="#taxonOptions">
+                       hx-target="#taxonOptions"
+                       hx-swap="innerHTML">
                 <datalist id="taxonOptions">
                 </datalist>
                 <div class="input-group-text">

--- a/web/templates/taxonomy_editgerm.html.j2
+++ b/web/templates/taxonomy_editgerm.html.j2
@@ -21,7 +21,8 @@
                          autofocus
                          hx-get="{{app_prefix}}/taxonomy/datalist"
                          hx-trigger="input changed delay:500ms"
-                         hx-target="#taxonOptions">
+                         hx-target="#taxonOptions"
+                         hx-swap="innerHTML">
                   <datalist id="taxonOptions">
                   </datalist>
               </div>


### PR DESCRIPTION
We need to explicitly specify hx-swap=innerHTML because the default was
overridden somewhere.

Signed-off-by: Jonathon Jongsma <jonathon@quotidian.org>
